### PR TITLE
Fix sankey hover

### DIFF
--- a/src/Sankey.js
+++ b/src/Sankey.js
@@ -255,7 +255,7 @@ export class Sankey {
           }
           return "rgba(148, 153, 168, 1)";
         })
-        .on('mouseover', d => this._highlightOnHover && this._showLinks(d))
+        .on('mouseover', d => this._highlightOnHover && this._showLinks(d.target?.__data__))
         .on('mouseout', _ => this._highlightOnHover && this._showAll());
 
     // LINKS


### PR DESCRIPTION
Fixes the `Cannot read properties of undefined (reading 'forEach')` error when hovering over nodes and links